### PR TITLE
feat(mobile): add Firefox for Android support

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,7 @@
 var popup_function = function(rows, package_info){
     // 確認有沒有 #CompanyInfo 的下方視窗
     if (!document.getElementById('CompanyInfo')) {
-        var content = var content = "<div id='CompanyInfo' style='width:100%; max-height: 20%; overflow-y: scroll; background: #cc103f; bottom: 0; padding: 5px; text-align: left; z-index: 99999; font-size: 14.5px; line-height: 1.5; color: #fff; position: fixed'>"
+        var content = "<div id='CompanyInfo' style='width:100%; max-height: 20%; overflow-y: scroll; background: #cc103f; bottom: 0; padding: 5px; text-align: left; z-index: 99999; font-size: 14.5px; line-height: 1.5; color: #fff; position: fixed'>"
             + "<ul id='CompanyInfoMessage' style='list-style-type: disc'></ul>"
             + "<div style='color:#fff;font-weight:bold;float:right;padding-right:8px;width:46px;'>"
             + "<span id='CompanyInfoClose' style='cursor:pointer;'>關閉</span>"                

--- a/background.js
+++ b/background.js
@@ -1,35 +1,35 @@
 var popup_function = function(rows, package_info){
     // 確認有沒有 #CompanyInfo 的下方視窗
     if (!document.getElementById('CompanyInfo')) {
-	var content = "<div id='CompanyInfo' style='max-height: 20%; overflow-y: scroll; background: #cc103f; bottom: 0; padding: 5px; text-align: left; z-index: 99999; font-size: 14.5px; line-height: 1.5; color: #fff; position: fixed'>"
-	    + "<ul id='CompanyInfoMessage' style='list-style-type: disc'></ul>"
-	    + "<div style='color:#fff;font-weight:bold;float:right;padding-right:8px;width:46px;'>"
-	    + "<span id='CompanyInfoClose' style='cursor:pointer;'>關閉</span>"                
-	    + "</div></div>";
-	document.body.innerHTML = content + document.body.innerHTML;
-	var close = document.getElementById('CompanyInfoClose');
+        var content = "<div id='CompanyInfo' style='max-height: 20%; overflow-y: scroll; background: #cc103f; bottom: 0; padding: 5px; text-align: left; z-index: 99999; font-size: 14.5px; line-height: 1.5; color: #fff; position: fixed'>"
+            + "<ul id='CompanyInfoMessage' style='list-style-type: disc'></ul>"
+            + "<div style='color:#fff;font-weight:bold;float:right;padding-right:8px;width:46px;'>"
+            + "<span id='CompanyInfoClose' style='cursor:pointer;'>關閉</span>"                
+            + "</div></div>";
+        document.body.innerHTML = content + document.body.innerHTML;
+        var close = document.getElementById('CompanyInfoClose');
 
-	close.addEventListener('click',function() {
-	    document.getElementById('CompanyInfo').style.display = 'none';
-	});
+        close.addEventListener('click',function() {
+            document.getElementById('CompanyInfo').style.display = 'none';
+        });
 
-	var info_dom = document.getElementById('CompanyInfo');
-	info_dom.style.background = 'yellow';
-	info_dom.style.color = 'black';
+        var info_dom = document.getElementById('CompanyInfo');
+        info_dom.style.background = 'yellow';
+        info_dom.style.color = 'black';
     }
 
     // 確認該資料包有沒有 <li>
     if (!document.getElementById('CompanyInfo-Package-' + package_info.id)) {
-	var content = '';
-	content += '<li>';
-	content += '<a href="' + htmlspecialchars(package_info.url) + '" target="_blank">' + htmlspecialchars(package_info.name) + '</a>';
-	content += '(共 <span id="CompanyInfo-PackageCount-' + package_info.id + '">1</span> 筆符合)';
-	if (package_info.notice) {
-	    content += '<a style="color: red" href="#" onclick="alert(this.title); return false;" title="' + htmlspecialchars(package_info.notice) + '">[注意!]</a>';
-	}
-	content += '<ol style="list-style-type: decimal" id="CompanyInfo-Package-' + package_info.id +'"></ol>';
-	content += '</li>';
-	document.getElementById('CompanyInfoMessage').innerHTML += content;
+        var content = '';
+        content += '<li>';
+        content += '<a href="' + htmlspecialchars(package_info.url) + '" target="_blank">' + htmlspecialchars(package_info.name) + '</a>';
+        content += '(共 <span id="CompanyInfo-PackageCount-' + package_info.id + '">1</span> 筆符合)';
+        if (package_info.notice) {
+            content += '<a style="color: red" href="#" onclick="alert(this.title); return false;" title="' + htmlspecialchars(package_info.notice) + '">[注意!]</a>';
+        }
+        content += '<ol style="list-style-type: decimal" id="CompanyInfo-Package-' + package_info.id +'"></ol>';
+        content += '</li>';
+        document.getElementById('CompanyInfoMessage').innerHTML += content;
     }
 
     // 塞資料

--- a/background.js
+++ b/background.js
@@ -1,7 +1,7 @@
 var popup_function = function(rows, package_info){
     // 確認有沒有 #CompanyInfo 的下方視窗
     if (!document.getElementById('CompanyInfo')) {
-        var content = "<div id='CompanyInfo' style='max-height: 20%; overflow-y: scroll; background: #cc103f; bottom: 0; padding: 5px; text-align: left; z-index: 99999; font-size: 14.5px; line-height: 1.5; color: #fff; position: fixed'>"
+        var content = var content = "<div id='CompanyInfo' style='width:100%; max-height: 20%; overflow-y: scroll; background: #cc103f; bottom: 0; padding: 5px; text-align: left; z-index: 99999; font-size: 14.5px; line-height: 1.5; color: #fff; position: fixed'>"
             + "<ul id='CompanyInfoMessage' style='list-style-type: disc'></ul>"
             + "<div style='color:#fff;font-weight:bold;float:right;padding-right:8px;width:46px;'>"
             + "<span id='CompanyInfoClose' style='cursor:pointer;'>關閉</span>"                
@@ -16,6 +16,10 @@ var popup_function = function(rows, package_info){
         var info_dom = document.getElementById('CompanyInfo');
         info_dom.style.background = 'yellow';
         info_dom.style.color = 'black';
+    }
+
+    if(!package_info) {
+        return;
     }
 
     // 確認該資料包有沒有 <li>
@@ -37,10 +41,10 @@ var popup_function = function(rows, package_info){
     content += '<li>';
     content += htmlspecialchars(rows[1]) + '. ' + htmlspecialchars(rows[2]);
     if (rows[3]) {
-        content += '[<a href="' + htmlspecialchars(rows[3]) + (rows[3].indexOf('?') >= 0 ? '&' : '?') + 'utm_source=jobhelper&utm_medium=web&utm_campaign=corp" target="_blank">原始連結</a>]';
+        content += '[<a style="display:inline" href="' + htmlspecialchars(rows[3]) + (rows[3].indexOf('?') >= 0 ? '&' : '?') + 'utm_source=jobhelper&utm_medium=web&utm_campaign=corp" target="_blank">原始連結</a>]';
     }
     if (rows[4]) {
-        content += '[<a href="' + htmlspecialchars(rows[4]) + '" target="_blank">截圖</a>]';
+        content += '[<a style="display:inline" href="' + htmlspecialchars(rows[4]) + '" target="_blank">截圖</a>]';
     }
     content += '</li>';
 
@@ -64,4 +68,4 @@ function onRequest(request, sender, sendResponse) {
 };
 
 // Listen for the content script to send a message to the background page.
-chrome.extension.onRequest.addListener(onRequest);
+chrome.runtime.onMessage.addListener(onRequest);

--- a/common.js
+++ b/common.js
@@ -38,12 +38,18 @@ var get_package_info = function(cb){
 };
 
 var update_packages = function(cb){
-    $.get('https://jobhelper.g0v.ronny.tw/api/getpackages', function(ret){
-        ret.fetch_at = (new Date()).getTime();
-        chrome.storage.local.set({packages: ret}, function(){
-            cb(ret);
-        });
-    }, 'json');
+    let xhr = new XMLHttpRequest();
+    xhr.onreadystatechange = function() {
+        if (this.readyState == 4) {
+            let ret = JSON.parse(this.responseText);
+            ret.fetch_at = (new Date()).getTime();
+            chrome.storage.local.set({packages: ret}, function(){
+                cb(ret);
+            });
+        };
+    };
+    xhr.open('get', 'https://jobhelper.g0v.ronny.tw/api/getpackages');
+    xhr.send('');
 };
 
 var _package_csv = null;
@@ -74,11 +80,17 @@ var get_package_csv_by_id = function(id, cb){
                 cb(package_csv[id].content);
                 return;
             }
-            $.get('https://jobhelper.g0v.ronny.tw/api/getpackage?id=' + parseInt(id), function(package_csv){
-                _package_csv[id] = package_csv;
-                chrome.storage.local.set({package_csv: _package_csv});
-                cb(_package_csv[id].content);
-            });
+            let xhr = new XMLHttpRequest();
+            xhr.onreadystatechange = function() {
+                if (this.readyState == 4) {
+                    let ret = JSON.parse(this.responseText);
+                    _package_csv[id] = package_csv;
+                    chrome.storage.local.set({package_csv: _package_csv});
+                    cb(_package_csv[id].content);
+                };
+            };
+            xhr.open('get', 'https://jobhelper.g0v.ronny.tw/api/getpackages');
+            xhr.send('');
         });
     });
 };
@@ -142,17 +154,23 @@ var search_package_by_name_api = function(name, url, cb, failed_cb){
         for (var id in choosed_packages) {
             packages.push(id);
         }
-        $.get('https://jobhelper.g0v.ronny.tw/api/search?name=' + encodeURIComponent(name) + '&url=' + encodeURIComponent(url) + '&packages=' + encodeURIComponent(packages.join(',')), function(ret){
-            if (ret.error) {
-                failed_cb(ret.message);
-                return;
-            }
-            var d;
-            for (var i = 0; i < ret.data.length; i ++) {
-                d = ret.data[i];
-                cb(d.package_id, [d.name, d.date, d.reason, d.link, d.snapshot]);
-            }
-        }, 'json');
+        let xhr = new XMLHttpRequest();
+        xhr.onreadystatechange = function() {
+            if (this.readyState == 4) {
+                let ret = JSON.parse(this.responseText);
+                if (ret.error) {
+                    failed_cb(ret.message);
+                    return;
+                }
+                var d;
+                for (var i = 0; i < ret.data.length; i ++) {
+                    d = ret.data[i];
+                    cb(d.package_id, [d.name, d.date, d.reason, d.link, d.snapshot]);
+                }
+            };
+        };
+        xhr.open('get', 'https://jobhelper.g0v.ronny.tw/api/search?name=' + encodeURIComponent(name) + '&url=' + encodeURIComponent(url) + '&packages=' + encodeURIComponent(packages.join(',')));
+        xhr.send('');
     });
 };
 

--- a/common.js
+++ b/common.js
@@ -12,7 +12,7 @@ var get_choosed_packages = function(cb){
             for (var i = 0; i < package_info.packages.length; i ++) {
                 current_package = package_info.packages[i];
                 if ('undefined' === typeof(items.choosed_packages[current_package.id])) {
-		    // 有指定 default=true 才會變成預設包
+                    // 有指定 default=true 才會變成預設包
                     if (current_package && current_package['default']) {
                         choosed_packages[current_package.id] = true;
                     }
@@ -51,7 +51,7 @@ var _package_csv = null;
 var get_package_csv_from_storage = function(cb){
     if (null !== _package_csv) {
         cb(_package_csv);
-	return;
+        return;
     }
     chrome.storage.local.get({package_csv: {}}, function(items){
         _package_csv = items.package_csv;
@@ -76,7 +76,7 @@ var get_package_csv_by_id = function(id, cb){
             }
             $.get('https://jobhelper.g0v.ronny.tw/api/getpackage?id=' + parseInt(id), function(package_csv){
                 _package_csv[id] = package_csv;
-		chrome.storage.local.set({package_csv: _package_csv});
+                chrome.storage.local.set({package_csv: _package_csv});
                 cb(_package_csv[id].content);
             });
         });
@@ -117,22 +117,22 @@ var check_name = function(web_name, db_name){
 
 var search_package_by_name = function(name, cb, checker){
     get_choosed_packages(function(choosed_packages){
-	for (var id in choosed_packages) {
-	    (function(id){
-		get_package_csv_by_id(id, function(package_csv){
-		    if ('undefined' == typeof(package_csv)) {
-			return;
-		    }
-		    var rows;
-		    for (var i = 0; i < package_csv.length; i ++) {
-			rows = package_csv[i];
-			if (checker(name, rows[0])) {
-			    cb(id, rows);
-			}
-		    }
-		});
-	    })(id);
-	}
+        for (var id in choosed_packages) {
+            (function(id){
+                get_package_csv_by_id(id, function(package_csv){
+                    if ('undefined' == typeof(package_csv)) {
+                        return;
+                    }
+                    var rows;
+                    for (var i = 0; i < package_csv.length; i ++) {
+                        rows = package_csv[i];
+                        if (checker(name, rows[0])) {
+                            cb(id, rows);
+                        }
+                    }
+                });
+            })(id);
+        }
     });
 };
 

--- a/contentscript.js
+++ b/contentscript.js
@@ -3,93 +3,93 @@ var get_company_info = function(){
     params.link = document.location.href;
 
     if ('www.104.com.tw' == document.location.hostname) {
-	// 有 jQuery 可以用
-	var company_dom = jQuery('#comp_header li.comp_name p a', document);
-	if (company_dom.length != 0) {
-	    params.from = '104-1';
-	    params.name = company_dom.eq(0).text();
-	    params.company_link = company_dom.eq(0).attr('href');
-	    return params;
-	}
+        // 有 jQuery 可以用
+        var company_dom = jQuery('#comp_header li.comp_name p a', document);
+        if (company_dom.length != 0) {
+            params.from = '104-1';
+            params.name = company_dom.eq(0).text();
+            params.company_link = company_dom.eq(0).attr('href');
+            return params;
+        }
 
-	company_dom = jQuery('#comp_header li.comp_name h1', document);
-	if (company_dom.length != 0) {
-	    params.from = '104-2';
-	    params.name = company_dom.text();
-	    params.company_link = document.location;
-	    return params;
-	}
+        company_dom = jQuery('#comp_header li.comp_name h1', document);
+        if (company_dom.length != 0) {
+            params.from = '104-2';
+            params.name = company_dom.text();
+            params.company_link = document.location;
+            return params;
+        }
 
     // http://www.104.com.tw/job/?jobno=3lluq&jobsource=n104bank1
-	company_dom = jQuery('span.company a:first', document);
-	if (company_dom.length != 0) {
-	    params.from = '104-3';
-	    params.name = company_dom.eq(0).text();
-	    params.company_link = company_dom.eq(0).attr('href');
-	    return params;
-	}
+        company_dom = jQuery('span.company a:first', document);
+        if (company_dom.length != 0) {
+            params.from = '104-3';
+            params.name = company_dom.eq(0).text();
+            params.company_link = company_dom.eq(0).attr('href');
+            return params;
+        }
 
-	// 104i
-	if (document.location.pathname.match('\/104i\/')) {
-	    // 單一公司頁，只有一個 <h1>, Ex: http://www.104.com.tw/jb/104i/cust/view?c=5e3a43255e363e2048323c1d1d1d1d5f2443a363189j01
-	    if (document.location.pathname.match('/cust/view')) {
-		var h1_dom = jQuery('#mainHeader h1.h1');
-		if (h1_dom.length == 1) {
-		    params.from = '104-4';
-		    params.name = h1_dom.text();
-		    return params;
-		}
-	    }
+        // 104i
+        if (document.location.pathname.match('\/104i\/')) {
+            // 單一公司頁，只有一個 <h1>, Ex: http://www.104.com.tw/jb/104i/cust/view?c=5e3a43255e363e2048323c1d1d1d1d5f2443a363189j01
+            if (document.location.pathname.match('/cust/view')) {
+                var h1_dom = jQuery('#mainHeader h1.h1');
+                if (h1_dom.length == 1) {
+                    params.from = '104-4';
+                    params.name = h1_dom.text();
+                    return params;
+                }
+            }
 
-	    // 工作頁
-	    if (document.location.pathname.match('/job/view')) {
-		var a_doms = $('#mainHeader a', document);
-		var a_dom;
-		for (var i = 0; i < a_doms.length; i ++) {
-		    a_dom = a_doms.eq(i);
-		    if (!a_dom.attr('href') || !a_dom.attr('href').match(/view\?c=/)) {
-			continue;
-		    }
-		    if (params.company_link && params.company_link != a_dom.attr('href')) {
-			// 有兩家不一樣的公司，跳過
-			return;
-		    }
-		    params.company_link = a_dom.attr('href');
-		    params.name = a_dom.text();
-		    params.from = '104-5';
-		}
-	    }
+            // 工作頁
+            if (document.location.pathname.match('/job/view')) {
+                var a_doms = $('#mainHeader a', document);
+                var a_dom;
+                for (var i = 0; i < a_doms.length; i ++) {
+                    a_dom = a_doms.eq(i);
+                    if (!a_dom.attr('href') || !a_dom.attr('href').match(/view\?c=/)) {
+                        continue;
+                    }
+                    if (params.company_link && params.company_link != a_dom.attr('href')) {
+                        // 有兩家不一樣的公司，跳過
+                        return;
+                    }
+                    params.company_link = a_dom.attr('href');
+                    params.name = a_dom.text();
+                    params.from = '104-5';
+                }
+            }
 
-	    return params;
-	}
-	
-	return;
+            return params;
+        }
+        
+        return;
     } else if ('www.taiwanjobs.gov.tw' == document.location.hostname) {
-	var company_dom = jQuery('#divcontent span:first',document);
-	if (company_dom.length != 0) {
-	    params.from = 'ejob-1';
-	    params.name = company_dom.text().trim();
-	    return params;
-	}
+        var company_dom = jQuery('#divcontent span:first',document);
+        if (company_dom.length != 0) {
+            params.from = 'ejob-1';
+            params.name = company_dom.text().trim();
+            return params;
+        }
     } else if ('www.104temp.com.tw' == document.location.hostname) {
-	// 檢查所有 a dom, 如果 company_intro.jsp 開頭的不超過兩個不一樣的，就確定是這家公司了
-	var a_doms = $('a', document);
-	var a_dom;
-	for (var i = 0; i < a_doms.length; i ++) {
-	    a_dom = a_doms.eq(i);
-	    if (!a_dom.attr('href') || !a_dom.attr('href').match(/^company_intro\.jsp/)) {
-		continue;
-	    }
-	    if (params.company_link && params.company_link != a_dom.attr('href')) {
-		// 有兩家不一樣的公司，跳過
-		return;
-	    }
-	    params.company_link = a_dom.attr('href');
-	    params.name = a_dom.text();
-	    params.from = '104temp-1';
-	}
+        // 檢查所有 a dom, 如果 company_intro.jsp 開頭的不超過兩個不一樣的，就確定是這家公司了
+        var a_doms = $('a', document);
+        var a_dom;
+        for (var i = 0; i < a_doms.length; i ++) {
+            a_dom = a_doms.eq(i);
+            if (!a_dom.attr('href') || !a_dom.attr('href').match(/^company_intro\.jsp/)) {
+                continue;
+            }
+            if (params.company_link && params.company_link != a_dom.attr('href')) {
+                // 有兩家不一樣的公司，跳過
+                return;
+            }
+            params.company_link = a_dom.attr('href');
+            params.name = a_dom.text();
+            params.from = '104temp-1';
+        }
 
-	return params;
+        return params;
     } else if ('www.yes123.com.tw' == document.location.hostname||'yes123.com.tw' == document.location.hostname) {
             // 處理小而美企業頁面
         if (jQuery('.dtitle').length == 1 && document.location.href.match('small_corp')) {
@@ -98,38 +98,38 @@ var get_company_info = function(){
             return params;
         }
             
-	var matches = document.location.search.match(/p_id=([^&]*)/);
-	if (!matches) {
-	    return;
-	}
-	
-	if (jQuery('.company_title').length==1) {
-		params.name = jQuery('.company_title').text();
+        var matches = document.location.search.match(/p_id=([^&]*)/);
+        if (!matches) {
+            return;
+        }
+        
+        if (jQuery('.company_title').length==1) {
+                params.name = jQuery('.company_title').text();
         params.from = 'yes123-2';
-	}else if (jQuery('.jobname_title a:first').length==1) {
-		params.name = jQuery('.jobname_title a:first').text();
+        }else if (jQuery('.jobname_title a:first').length==1) {
+                params.name = jQuery('.jobname_title a:first').text();
         params.from = 'yes123-3';
-	}
+        }
 
-	params.company_link = matches[1];
-	return params;
+        params.company_link = matches[1];
+        return params;
     } else if ('www.1111.com.tw' == document.location.hostname) {
-	var found = false;
+        var found = false;
 
         // check HTML   <li><a href="/job-bank/company-description.asp?nNo=2765266"></a></li>
         jQuery('#commonTop li a').each(function(){
             var href = $(this).attr('href');
             if ('string' == typeof(href) && href.match('/job-bank/company-description\.asp\\?nNo=[^&]*')) {
                 params.from = '1111-1';
-		params.name = $(this).text();
-		params.company_link = $(this).attr('href');
-		found = true;
-		return false;
+                params.name = $(this).text();
+                params.company_link = $(this).attr('href');
+                found = true;
+                return false;
             }
         });
-	if (found) {
-	    return params;
-	}
+        if (found) {
+            return params;
+        }
 
         if ('object' === typeof(vizLayer) && 'string' === typeof(vizLayer.catname)) {
             params.from = '1111-2';
@@ -137,35 +137,35 @@ var get_company_info = function(){
             params.company_link = '#';
             return params;
         }
-	jQuery('#breadcrumb li a').each(function(){
-	    var self = $(this);
+        jQuery('#breadcrumb li a').each(function(){
+            var self = $(this);
 
-	    if (self.attr('href').match(/找工作機會/)) {
-		params.from = '1111-3';
-		params.name = self.text();
-		params.company_link = self.attr('href');
-		found = true;
-		return false;
-	    }
-	});
-	if (found) {
-	    return params;
-	}
+            if (self.attr('href').match(/找工作機會/)) {
+                params.from = '1111-3';
+                params.name = self.text();
+                params.company_link = self.attr('href');
+                found = true;
+                return false;
+            }
+        });
+        if (found) {
+            return params;
+        }
 
-	jQuery('div.path a').each(function(){
-	    var self = $(this);
+        jQuery('div.path a').each(function(){
+            var self = $(this);
 
-	    if (self.attr('href').match(/找工作機會/)) {
-		params.from = '1111-4';
-		params.name = self.text();
-		params.company_link = self.attr('href');
-		found = true;
-		return false;
-	    }
-	});
-	if (found) {
-	    return params;
-	}
+            if (self.attr('href').match(/找工作機會/)) {
+                params.from = '1111-4';
+                params.name = self.text();
+                params.company_link = self.attr('href');
+                found = true;
+                return false;
+            }
+        });
+        if (found) {
+            return params;
+        }
 
         var decoded_url = decodeURIComponent(document.location.href);
         // 網址中有「找工作」和「找工作機會」都可以
@@ -204,16 +204,16 @@ var get_company_info = function(){
             return params;
         }
 
-	if (!jQuery('.company-info h2 a').length) {
-	    return;
-	}
+        if (!jQuery('.company-info h2 a').length) {
+            return;
+        }
 
-	var dom = jQuery('.company-info h2 a');
-	params.from = '518-5';
-	params.name = dom.text();
-	params.company_link = dom.attr('href');
+        var dom = jQuery('.company-info h2 a');
+        params.from = '518-5';
+        params.name = dom.text();
+        params.company_link = dom.attr('href');
     } else {
-	return;
+        return;
     }
 
     return params;

--- a/manifest.json
+++ b/manifest.json
@@ -1,26 +1,32 @@
 {
+  "applications": {
+    "gecko": {
+      "id": "job@github.com",
+      "strict_min_version": "48.0"
+    }
+  },
+    
   "manifest_version": 2,
 
   "name": "求職小幫手",
   "description": "讓你更加了解這家公司",
-  "version": "1.3.10",
+  "version": "1.4.0",
 
   "background" : {
-      "scripts": ["background.js"]
+      "scripts": [ "background.js"]
   },
   "permissions": [
-      "http://jobhelper.g0v.ronny.tw/",
-      "https://jobhelper.g0v.ronny.tw/",
-      "http://www.taiwanjobs.gov.tw/",
-      "http://www.104.com.tw/",
-      "https://www.104.com.tw/",
-      "http://www.ejob.gov.tw/",
-      "https://www.ejob.gov.tw/",
-      "http://www.104temp.com.tw/",
-      "http://www.1111.com.tw/",
-      "https://www.1111.com.tw/",
-      "http://www.yes123.com.tw/",
-      "http://www.518.com.tw/",
+      "*://jobhelper.g0v.ronny.tw/",
+      "*://www.taiwanjobs.gov.tw/",
+      "*://104.com.tw/",
+      "*://www.104.com.tw/",
+      "*://m.104.com.tw/",
+      "*://www.ejob.gov.tw/",
+      "*://www.104temp.com.tw/",
+      "*://www.1111.com.tw/",
+      "*://www.yes123.com.tw/",
+      "*://www.518.com.tw/",
+      "*://m.518.com.tw/",
       "tabs",
       "storage"
   ],
@@ -32,16 +38,16 @@
   "content_scripts" : [
     {
       "matches" : [
-        "http://www.104.com.tw/*",
-        "https://www.104.com.tw/*",
-        "http://www.taiwanjobs.gov.tw/*",
-        "http://www.ejob.gov.tw/*",
-        "https://www.ejob.gov.tw/*",
-        "http://www.104temp.com.tw/*",
-        "http://www.1111.com.tw/*",
-        "https://www.1111.com.tw/*",
-        "http://www.yes123.com.tw/*",
-        "http://www.518.com.tw/*"
+        "*://104.com.tw/*",
+        "*://www.104.com.tw/*",
+        "*://m.104.com.tw/*",
+        "*://www.taiwanjobs.gov.tw/*",
+        "*://www.ejob.gov.tw/*",
+        "*://www.104temp.com.tw/*",
+        "*://www.1111.com.tw/*",
+        "*://www.yes123.com.tw/*",
+        "*://www.518.com.tw/*",
+        "*://m.518.com.tw/*"
       ],
       "js" : ["jquery.min.js", "common.js", "contentscript.js"],
       "run_at" : "document_idle",

--- a/manifest.json
+++ b/manifest.json
@@ -38,10 +38,10 @@
         "http://www.ejob.gov.tw/*",
         "https://www.ejob.gov.tw/*",
         "http://www.104temp.com.tw/*",
-	"http://www.1111.com.tw/*",
-	"https://www.1111.com.tw/*",
-	"http://www.yes123.com.tw/*",
-	"http://www.518.com.tw/*"
+        "http://www.1111.com.tw/*",
+        "https://www.1111.com.tw/*",
+        "http://www.yes123.com.tw/*",
+        "http://www.518.com.tw/*"
       ],
       "js" : ["jquery.min.js", "common.js", "contentscript.js"],
       "run_at" : "document_idle",


### PR DESCRIPTION
Firefox for Android開始支援Chrome extension API了，做了一些修改讓元件可以在Firefox for Android 48.0上執行
- 增加104,1111,518行動版網頁的規則。
- Firefox的相容性修改，包含`extension.sendRequest`及`XMLHttpRequest`等。
- 將[關閉]移至頂端。

Android上的螢幕擷圖: https://ayukawayen.github.io/pages/jobhelper/
