### PR TITLE
修正使用 innerHTML 會導致頁面上的js失效的問題

### DIFF
--- a/background.js
+++ b/background.js
@@ -6,7 +6,8 @@ var popup_function = function(rows, package_info){
 	    + "<div style='color:#fff;font-weight:bold;float:right;padding-right:8px;width:46px;'>"
 	    + "<span id='CompanyInfoClose' style='cursor:pointer;'>關閉</span>"                
 	    + "</div></div>";
-	document.body.innerHTML = content + document.body.innerHTML;
+	document.body.insertAdjacentHTML( 'beforeend', content );
+	
 	var close = document.getElementById('CompanyInfoClose');
 
 	close.addEventListener('click',function() {


### PR DESCRIPTION
目前的求職小幫手如果載入頁面，因為使用innerHTML，會導致原本頁面上所有js都無法運作
改用insertadjacenthtml可以避免這個問題，支援度可到IE10以上
https://caniuse.com/#feat=insertadjacenthtml